### PR TITLE
fixing searching and filtering

### DIFF
--- a/frontend/src/app/modules/mips/pages/list-page/list-page.component.ts
+++ b/frontend/src/app/modules/mips/pages/list-page/list-page.component.ts
@@ -116,7 +116,6 @@ export class ListPageComponent implements OnInit, AfterViewInit {
   initFiltersAndSearch() {
     this.initFiltersStatus();
     this.initSearch();
-    this.filter.equals.push({field: 'proposal', value: ""});  // no subproposals
   }
 
   initSearch() {
@@ -228,6 +227,18 @@ export class ListPageComponent implements OnInit, AfterViewInit {
   }
 
   searchMips(): void {
+    let index = this.filter.equals.findIndex(item => item.field === 'proposal');
+
+    if (this.filterOrSearch()) {  // filter or search
+      if (index !== -1) {
+        this.filter.equals.splice(index, 1);  // include subproposals in searching
+      }
+    } else {
+      if (index === -1) {
+        this.filter.equals.push({field: 'proposal', value: ""});  // no subproposals
+      }
+    }
+
     this.mipsService.searchMips(this.limit, this.page, this.order, this.search, this.filter, 'title proposal filename mipName paragraphSummary sentenceSummary mip status')
     .subscribe(data => {
       this.mipsAux = data.items;
@@ -260,6 +271,19 @@ export class ListPageComponent implements OnInit, AfterViewInit {
         this.errorMessage = '';
       }
     });
+  }
+
+  filterOrSearch(): boolean {
+    if (
+      this.filter.contains.length ||
+      this.filter.inarray.length ||
+      this.filter.notcontains.length ||
+      this.search
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   searchMipsByName(limit, page, order, search, filter): void {


### PR DESCRIPTION
- It is not permitting to search sub-proposals, Subproposals should be searcheable as well. See [example not working in new implementation](https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60a629ea824e9b4f3c4c7911/1a87e5d5e7a3d4957590db049dd39f8a/image.png), it is possible to search SubProposal [in previous implementation](https://trello-attachments.s3.amazonaws.com/60a629ea824e9b4f3c4c7911/1199x300/0b17bbef679711b14f360f19135190a0/image.png)