### PR TITLE
fixing issue when showing tooltip of mip title in Mac/safari browser

### DIFF
--- a/frontend/src/app/modules/mips/components/list/list.component.html
+++ b/frontend/src/app/modules/mips/components/list/list.component.html
@@ -35,9 +35,15 @@
              <!-- <span class="tooltiptext">Click for more details</span>  -->
              <a
                 routerLink="/mips/details/{{ element.mipName }}"
-                [matTooltip]="element[column]"
-                [matTooltipClass]="{ 'mat-tooltip': true }"
-                ><br />{{ element[column] }}</a
+                style="position: relative;"
+                >
+                <div
+                  class="cover"
+                  [matTooltip]="element[column]"
+                  [matTooltipClass]="{ 'mat-tooltip': true }"
+                  #tooltip="matTooltip"
+                  (mouseover)="tooltip.show()"
+                ></div><br />{{ element[column] }}</a
               >
              </td>
          </span>

--- a/frontend/src/app/modules/mips/components/list/list.component.scss
+++ b/frontend/src/app/modules/mips/components/list/list.component.scss
@@ -529,6 +529,15 @@ a {
   background-color: rgba(26, 171, 155, 0.9);
 }
 
+.cover {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  top: 0;
+  left: 0;
+}
+
 @media screen and (max-width: 768px) {
   .mobile {
     width: 100%;


### PR DESCRIPTION
- On MAC the whole title is displayed twice, in both proposals and sub-proposals. See: https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60d4be9127b05b39ad72bc6d/5ce09e3298ec82c23e8ef2b30e216453/2.JPG ; https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60d4be9127b05b39ad72bc6d/b415b735dbe94b9f57c59693647bd5c8/1..JPG Everywhere else there are no problems.
