### PR TITLE
Feature/trello 96 general qc issues

### DIFF
--- a/frontend/src/app/shared/menu/menu.component.scss
+++ b/frontend/src/app/shared/menu/menu.component.scss
@@ -20,13 +20,13 @@
     align-items: center;
     width: 100%;
     transition: all 0.2s;
-    gap: 8px;
 
     .arrowContainer {
       position: relative;
       height: 5px;
       width: 7px;
       transition: transform 0.2s;
+      margin-left: 8px;
 
       .arrow {
         position: absolute;


### PR DESCRIPTION
- In the mobile, menu, please add an space between the end of the text and arrow. See [image.png](https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60daeadba54c748f4aa069be/15c29d03e21254be8c452aac8d4837c9/image.png) 
