### PR TITLE
hide Obsolete and Rejected mips in default list view

### DIFF
--- a/frontend/src/app/modules/mips/pages/list-page/list-page.component.ts
+++ b/frontend/src/app/modules/mips/pages/list-page/list-page.component.ts
@@ -23,6 +23,7 @@ export class ListPageComponent implements OnInit, AfterViewInit {
   page = 0;
   order: string;
   search: string = '';
+  searchCopy: string = '';
   filter: any;
   filterSaved: FilterData;
   loading: boolean;
@@ -37,6 +38,7 @@ export class ListPageComponent implements OnInit, AfterViewInit {
   mipsByName: any[] = [];
   sintaxError: boolean = false;
   errorMessage: string = '';
+  defaultSearch: string = "$ and(not(@Obsolete), not(@Withdrawn))";
 
   constructor(
     private mipsService: MipsService,
@@ -115,6 +117,19 @@ export class ListPageComponent implements OnInit, AfterViewInit {
     };
 
     this.queryParamsListService.queryParams = qp;
+
+    this.searchCopy = this.defaultSearch;
+
+    for (const key in qp) {
+      if (Object.prototype.hasOwnProperty.call(qp, key)) {
+        const element = qp[key];
+
+        if (element && (element as [])?.length != 0) {
+          this.searchCopy = this.search;
+          break;
+        }
+      }
+    }
   }
 
   initFiltersAndSearch() {
@@ -262,12 +277,18 @@ export class ListPageComponent implements OnInit, AfterViewInit {
       }
     }
 
+    this.searchCopy = this.defaultSearch;
+
+    if (this.filterOrSearch()) {
+      this.searchCopy = this.search;
+    }
+
     this.mipsService
       .searchMips(
         this.limit,
         this.page,
         this.order,
-        this.search,
+        this.searchCopy,
         this.filter,
         'title proposal filename mipName paragraphSummary sentenceSummary mip status mipFather'
       )


### PR DESCRIPTION
- https://trello.com/c/WrILvWt9/83-withdrawn-and-obsolete-mips-should-be-hidden-in-the-default-view
