### PR TITLE
fixing style of link in details mips view for safari

### DIFF
--- a/frontend/src/app/modules/mips/components/detail-content/detail-content.component.scss
+++ b/frontend/src/app/modules/mips/components/detail-content/detail-content.component.scss
@@ -99,6 +99,8 @@
 
     &:hover {
       a.anchor {
+        outline: none;
+
         i {
           visibility: visible;
         }
@@ -109,12 +111,15 @@
       color: black;
       position: absolute;
       left: -20px;
+      outline: none;
 
       i {
         visibility: hidden;
       }
 
       &:hover {
+        outline: none;
+
         i {
           visibility: visible;
         }


### PR DESCRIPTION
- **Description** While loading directly the concrete URL on MAC a blue square should not appear. **See:** https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60daeadba54c748f4aa069be/cd719eae6a0c9b1d66500723864a56a9/blue_square.png **Actual output** blue square appears **Expected output** nothing should appear in place of the blue square
