### PR TITLE
fixing outline css style in mips details link

### DIFF
--- a/frontend/src/app/modules/mips/components/detail-content/detail-content.component.scss
+++ b/frontend/src/app/modules/mips/components/detail-content/detail-content.component.scss
@@ -162,6 +162,8 @@
 
     &:hover {
       a.anchor {
+        outline: none;
+
         i {
           visibility: visible;
         }
@@ -172,12 +174,15 @@
       color: black;
       position: absolute;
       left: -20px;
+      outline: none;
 
       i {
         visibility: hidden;
       }
 
       &:hover {
+        outline: none;
+
         i {
           visibility: visible;
         }
@@ -186,6 +191,8 @@
   }
 
   a.anchor {
+    outline: none;
+
     &:hover {
       text-decoration: underline;
     }


### PR DESCRIPTION
- **Description** While loading directly the concrete URL on MAC a blue square should not appear. **See:** https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60daeadba54c748f4aa069be/cd719eae6a0c9b1d66500723864a56a9/blue_square.png **Actual output** blue square appears **Expected output** nothing should appear in place of the blue square
