### PR TITLE
close the autocomplete options as soons as the user scroll

### DIFF
--- a/frontend/src/app/modules/mips/directives/autocomplete.directive.ts
+++ b/frontend/src/app/modules/mips/directives/autocomplete.directive.ts
@@ -198,7 +198,7 @@ export class AutocompleteDirective {
       maxHeight: 25 * 6,
       maxWidth: 'fit-content',
       backdropClass: '',
-      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      scrollStrategy: this.overlay.scrollStrategies.close(),
       positionStrategy: this.getOverlayPosition(),
     });
 


### PR DESCRIPTION
- https://trello.com/c/dG9bhTsv/129-make-the-window-with-statuses-disappear-when-scrolling
