### PR TITLE
fixing issue when scrolling down fast

### DIFF
--- a/frontend/src/app/modules/mips/components/list/list.component.html
+++ b/frontend/src/app/modules/mips/components/list/list.component.html
@@ -6,7 +6,7 @@
     <div
       infiniteScroll
       [infiniteScrollDistance]="0"
-      [infiniteScrollThrottle]="10"
+      [infiniteScrollThrottle]="1"
       (scrolled)="onScroll()"
     >
       <table


### PR DESCRIPTION
- **Description** The issue still happened in Microsoft Edge and Windows. **Expected Output** Scrolling fast through all the MIPs should be possible without any problems. It never should stop without the possibility to continue scrolling.

