### PR TITLE
fixing issue in mipset groups when expand subsets

### DIFF
--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
@@ -90,14 +90,12 @@
           [ngStyle]="{
             color: expandedElementMipset === element ? '#B8C5D3' : ''
           }"
-          (click)="onExpandMipset(element)"
         >
           {{ element[column] | tagMipset | titlecase }}
-          <div (click)="onClickButtonCaptureEvent($event)">
+          <div>
             <button
               class="arrow-container"
               [disabled]="element.loadingSubproposals"
-              (click)="onExpandMipset(element)"
               (mouseover)="onMouseOverLeaveMipsetArrow(element.mipset, true)"
               (mouseleave)="onMouseOverLeaveMipsetArrow(element.mipset, false)"
               style="right: 0; position: relative;"
@@ -163,10 +161,7 @@
       *matRowDef="let element; columns: columnsToDisplayMipset"
       class="maker-element-mipset-row"
       [class.maker-expanded-row]="expandedElementMipset === element"
-      (click)="
-        expandedElementMipset =
-          expandedElementMipset === element ? null : element
-      "
+      (click)="onExpandMipset(element)"
     ></tr>
     <tr
       mat-row
@@ -187,14 +182,10 @@
             {{ itemMipset.mipset | tagMipset | titlecase }}</span
           >
         </div>
-        <div
-          class="subproposalsButtonWrapper"
-          (click)="onClickButtonCaptureEvent($event)"
-        >
+        <div class="subproposalsButtonWrapper">
           <button
             class="arrow-container"
             [disabled]="false"
-            (click)="onExpandMipset(itemMipset)"
             style="right: 0; top: 24px; transform: translateY(-50%);"
           >
             <div

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
@@ -151,7 +151,7 @@
           "
         >
           <ng-container>
-            <app-sublist [dataSource]="mips"></app-sublist>
+            <app-sublist [dataSource]="mipSets[element.mipset]"></app-sublist>
           </ng-container>
         </div>
       </td>
@@ -217,7 +217,7 @@
         "
       >
         <div
-          *ngFor="let itemMipsetChildren of mips"
+          *ngFor="let itemMipsetChildren of mipSets[itemMipset.mipset]"
           class="mobile-container"
           [ngClass]="{
             'proposal-card': !itemMipsetChildren.proposal,

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
@@ -90,6 +90,7 @@
           [ngStyle]="{
             color: expandedElementMipset === element ? '#B8C5D3' : ''
           }"
+          (click)="onExpandMipset(element)"
         >
           {{ element[column] | tagMipset | titlecase }}
           <div (click)="onClickButtonCaptureEvent($event)">
@@ -176,7 +177,11 @@
 
   <ng-container *ngIf="!loading">
     <div *ngFor="let itemMipset of dataSourceMipsetRows" class="mobile">
-      <div class="mobile-container subproposal-card-subset">
+      <button
+        mat-button
+        class="mobile-container subproposal-card-subset"
+        (click)="onExpandMipset(itemMipset)"
+      >
         <div style="width: calc(100% - 35px);">
           <span class="title">
             {{ itemMipset.mipset | tagMipset | titlecase }}</span
@@ -209,7 +214,7 @@
             </div>
           </button>
         </div>
-      </div>
+      </button>
 
       <div
         [@mipsetExpand]="

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.scss
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.scss
@@ -516,6 +516,8 @@ a {
   color: #748aa1;
   margin-right: 0;
   margin-left: auto;
+  line-height: normal;
+  text-align: left;
 
   .title {
     color: #748aa1;

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
@@ -133,11 +133,6 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
       );
   }
 
-  // usefull for stop event click propagation when button for get subproposals is disabled and clicked
-  onClickButtonCaptureEvent(e: Event) {
-    e.stopPropagation();
-  }
-
   onMouseOverLeaveMipsetArrow(mipset: any, value: boolean) {
     this.isArrowDownOnMouseOver = value;
     this.currentRowOver = mipset;

--- a/frontend/src/app/modules/mips/pages/list-page/list-page.component.html
+++ b/frontend/src/app/modules/mips/pages/list-page/list-page.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <p class="title" [ngClass]="{ hide: mobileSearch }">
-    {{ mipsetMode ? "MIP-Sets" : "MIPs List" }}
+    {{ mipsetMode ? "MIP Sets" : "MIPs List" }}
   </p>
   <div
     class="filtering"


### PR DESCRIPTION
- **Description** When expanding the MIP-Sets the displayed MIPs are not showing the correct sets of MIPs. Also, it happens that after refreshing these sets are changing which should not happen. It happens in all the browsers on the computer: on a mobile, it's working well. **See:** https://www.loom.com/share/855d4f7592bb428b8223ebc481f29731
