### PR TITLE
fixing issue in mipset mode when expand a row

### DIFF
--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
@@ -178,7 +178,7 @@
         (click)="onExpandMipset(itemMipset)"
       >
         <div style="width: calc(100% - 35px);">
-          <span class="title">
+          <span class="title" style="font-size: 18px;">
             {{ itemMipset.mipset | tagMipset | titlecase }}</span
           >
         </div>

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
@@ -21,7 +21,11 @@ const clone = require('rfdc')();
       state('collapsed', style({ height: '0px', minHeight: '0' })),
       state('expanded', style({ height: '*' })),
       transition(
-        'expanded <=> collapsed',
+        'expanded => collapsed',
+        animate('225ms 225ms cubic-bezier(0.4, 0.0, 0.2, 1)')
+      ),
+      transition(
+        'collapsed => expanded',
         animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')
       ),
     ]),
@@ -32,7 +36,11 @@ const clone = require('rfdc')();
       ),
       state('expanded', style({ height: '*' })),
       transition(
-        'expanded <=> collapsed',
+        'expanded => collapsed',
+        animate('525ms 525ms cubic-bezier(0.4, 0.0, 0.2, 1)')
+      ),
+      transition(
+        'collapsed => expanded',
         animate('525ms cubic-bezier(0.4, 0.0, 0.2, 1)')
       ),
     ]),


### PR DESCRIPTION
- **Description** When expanding the MIP Set on the mobile, the Subproposals are sometimes displayed from the bottom.  Everywhere else it works well. **See:** [image.png](https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60d4b925f430c74054db5bfc/1919420f9c51427095d4c59aba91be4e/image.png) Also, the titles are very small in comparison to the view on the computer. **Expected Output** When a user clicks on the MIP Set to expand Subproposals belonging to it, they should open from the top like it happens with the first MIP Set, not from the bottom as it happens in the rest of the cases. Regarding the titles size, please check if it's correct.
