### PR TITLE
fixing issue when expand a mipset

### DIFF
--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.html
@@ -88,7 +88,7 @@
           *matCellDef="let element"
           style="cursor: pointer; position: relative;"
           [ngStyle]="{
-            color: expandedElementMipset === element ? '#B8C5D3' : ''
+            color: element.expanded ? '#B8C5D3' : ''
           }"
         >
           {{ element[column] | tagMipset | titlecase }}
@@ -100,14 +100,14 @@
               (mouseleave)="onMouseOverLeaveMipsetArrow(element.mipset, false)"
               style="right: 0; position: relative;"
               [ngClass]="{
-                'dark-expand-arrow': expandedElementMipset !== element,
-                'shine-expand-arrow': expandedElementMipset === element
+                'dark-expand-arrow': !element.expanded,
+                'shine-expand-arrow': element.expanded
               }"
             >
               <div
                 class="arrow-wrapper expanded"
                 [ngClass]="{
-                  rotate: expandedElementMipset === element
+                  rotate: element.expanded
                 }"
               >
                 <svg
@@ -119,12 +119,12 @@
                   class="arrow"
                 >
                   <path
-                    *ngIf="expandedElementMipset !== element"
+                    *ngIf="!element.expanded"
                     d="M3.91278 4.79436C3.70724 5.06854 3.29276 5.06854 3.08722 4.79436L0.102225 0.812461C-0.149574 0.476568 0.0925517 -6.03868e-07 0.515005 -5.66936e-07L6.485 -4.50231e-08C6.90745 -8.09104e-09 7.14957 0.476568 6.89778 0.812461L3.91278 4.79436Z"
                     fill="#748AA1"
                   />
                   <path
-                    *ngIf="expandedElementMipset === element"
+                    *ngIf="element.expanded"
                     d="M3.91278 4.79436C3.70724 5.06854 3.29276 5.06854 3.08722 4.79436L0.102225 0.812461C-0.149574 0.476568 0.0925517 -6.03868e-07 0.515005 -5.66936e-07L6.485 -4.50231e-08C6.90745 -8.09104e-09 7.14957 0.476568 6.89778 0.812461L3.91278 4.79436Z"
                     fill="#B8C5D3"
                   />
@@ -145,9 +145,7 @@
       >
         <div
           class="maker-element-subsetchildren-detail"
-          [@detailExpand]="
-            element == expandedElementMipset ? 'expanded' : 'collapsed'
-          "
+          [@detailExpand]="element.expanded ? 'expanded' : 'collapsed'"
         >
           <ng-container>
             <app-sublist [dataSource]="mipSets[element.mipset]"></app-sublist>
@@ -160,7 +158,7 @@
       mat-row
       *matRowDef="let element; columns: columnsToDisplayMipset"
       class="maker-element-mipset-row"
-      [class.maker-expanded-row]="expandedElementMipset === element"
+      [class.maker-expanded-row]="element.expanded"
       (click)="onExpandMipset(element)"
     ></tr>
     <tr
@@ -178,7 +176,7 @@
         (click)="onExpandMipset(itemMipset)"
       >
         <div style="width: calc(100% - 35px);">
-          <span class="title" style="font-size: 18px;">
+          <span class="title" style="font-size: 20px;">
             {{ itemMipset.mipset | tagMipset | titlecase }}</span
           >
         </div>
@@ -191,7 +189,7 @@
             <div
               class="arrow-wrapper expanded"
               [ngClass]="{
-                rotate: expandedElementMipset == itemMipset
+                rotate: itemMipset.expanded
               }"
             >
               <img
@@ -207,11 +205,7 @@
         </div>
       </button>
 
-      <div
-        [@mipsetExpand]="
-          expandedElementMipset == itemMipset ? 'expanded' : 'collapsed'
-        "
-      >
+      <div [@mipsetExpand]="itemMipset.expanded ? 'expanded' : 'collapsed'">
         <div
           *ngFor="let itemMipsetChildren of mipSets[itemMipset.mipset]"
           class="mobile-container"

--- a/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
+++ b/frontend/src/app/modules/mips/components/list-mipset-mode/list-mipset-mode.component.ts
@@ -21,11 +21,7 @@ const clone = require('rfdc')();
       state('collapsed', style({ height: '0px', minHeight: '0' })),
       state('expanded', style({ height: '*' })),
       transition(
-        'expanded => collapsed',
-        animate('225ms 225ms cubic-bezier(0.4, 0.0, 0.2, 1)')
-      ),
-      transition(
-        'collapsed => expanded',
+        'expanded <=> collapsed',
         animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')
       ),
     ]),
@@ -36,11 +32,7 @@ const clone = require('rfdc')();
       ),
       state('expanded', style({ height: '*' })),
       transition(
-        'expanded => collapsed',
-        animate('525ms 525ms cubic-bezier(0.4, 0.0, 0.2, 1)')
-      ),
-      transition(
-        'collapsed => expanded',
+        'expanded <=> collapsed',
         animate('525ms cubic-bezier(0.4, 0.0, 0.2, 1)')
       ),
     ]),
@@ -127,6 +119,7 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
 
           this.dataSourceMipsetRows.forEach((item: IMIPsetDataElement) => {
             this.mipSets[item.mipset] = [];
+            item.expanded = false;
           });
 
           if (this.dataSourceMipsetRows.length > 0) {
@@ -146,9 +139,9 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
     this.currentRowOver = mipset;
   }
 
-  onExpandMipset(row) {
-    if (this.expandedElementMipset === row) {
-      this.expandedElementMipset = null;
+  onExpandMipset(row: IMIPsetDataElement) {
+    if (row.expanded) {
+      row.expanded = false;
     } else {
       let filter = clone(this.filterClone);
       filter.contains.push({ field: 'tags', value: row.mipset });
@@ -164,7 +157,7 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
         .subscribe(
           (data) => {
             this.mipSets[row.mipset] = data.items;
-            this.expandedElementMipset = row;
+            row.expanded = true;
           },
           (error) => {
             console.log(error);
@@ -173,7 +166,7 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
     }
   }
 
-  async expandFirstMipset(row) {
+  async expandFirstMipset(row: IMIPsetDataElement) {
     try {
       let filter = clone(this.filterClone);
       filter.contains.push({ field: 'tags', value: row.mipset });
@@ -189,7 +182,7 @@ export class ListMipsetModeComponent implements OnInit, OnChanges {
         )
         .toPromise();
       this.mipSets[row.mipset] = data.items;
-      this.expandedElementMipset = row;
+      row.expanded = true;
 
       return;
     } catch (error) {

--- a/frontend/src/app/modules/mips/types/mipset.ts
+++ b/frontend/src/app/modules/mips/types/mipset.ts
@@ -1,3 +1,4 @@
 export interface IMIPsetDataElement {
   mipset: string;
+  expanded?: boolean;
 }


### PR DESCRIPTION
- **Description** When expanding the MIP Set on the mobile, the Subproposals are sometimes displayed from the bottom.  Everywhere else it works well. **See:** [image.png](https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60d4b925f430c74054db5bfc/1919420f9c51427095d4c59aba91be4e/image.png) Also, the titles are very small in comparison to the view on the computer. **See:** https://trello-attachments.s3.amazonaws.com/5fe49ee0c696f31b95f2200e/60d4b925f430c74054db5bfc/29421897812f8b726f62f6b12d01a61a/telefon.mp4 **Expected Output** When a user clicks on the MIP Set to expand Subproposals belonging to it, they should open from the top as it happens with the first MIP Set, not from the bottom as it happens in the rest of the cases. Regarding the size of the titles, please check if it's correct. 
