### PR TITLE
adding a hyphen in component name in mips list view for mobile

### DIFF
--- a/frontend/src/app/modules/mips/components/list/list.component.html
+++ b/frontend/src/app/modules/mips/components/list/list.component.html
@@ -393,7 +393,7 @@
               <div *ngFor="let itemSubset of item.subsetRows">
                 <div class="mobile-container subproposal-card-subset">
                   <div style="width: calc(100% - 35px);">
-                    <span class="title"> {{ itemSubset.subset + " : " + itemSubset.title }}</span>
+                    <span class="title"> {{ itemSubset.subset + " - " + itemSubset.title }}</span>
                   </div>
                   <div
                     class="subproposalsButtonWrapper"


### PR DESCRIPTION
- https://trello.com/c/dJqHOVbB/122-display-the-name-of-the-component-after-expanding-a-mip
