### PR TITLE
Fix/remove the ability sort by summary main page

### DIFF
--- a/frontend/src/app/modules/mips/components/list/list.component.html
+++ b/frontend/src/app/modules/mips/components/list/list.component.html
@@ -98,13 +98,14 @@
               <th
                 mat-header-cell
                 *matHeaderCellDef
-                (click)="onSendOrder(column)"
-                style="cursor: pointer"
-                class="titlePost"
+                (click)="onSendOrder(column)"         
               >
                 <span class="headerContent"
+                style="cursor: pointer; padding-right: 50px;"
+                class="titlePost"
                   >#
                   <app-asc-des
+                  style="padding-left: 3px;"
                     [direction]="getOrderDirection(column)"
                   ></app-asc-des
                 ></span>

--- a/frontend/src/app/modules/mips/components/list/list.component.html
+++ b/frontend/src/app/modules/mips/components/list/list.component.html
@@ -35,7 +35,7 @@
               >
                 <span class="headerContent"
                   >{{ column | translate
-                  }}<app-asc-des
+                  }}<app-asc-des *ngIf="column!='summary'"
                     [direction]="getOrderDirection(column)"
                   ></app-asc-des
                 ></span>

--- a/frontend/src/app/modules/mips/components/list/list.component.scss
+++ b/frontend/src/app/modules/mips/components/list/list.component.scss
@@ -197,8 +197,8 @@ th {
 }
 
 .mat-column-pos {
-  width: 7%;
-  max-width: 10px;
+  width: 10%;
+  max-width: 20px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -994,5 +994,6 @@ tr.maker-element-subsetchildren-row:not(.maker-expanded-row):hover {
   padding-right: 90px !important;
 }
 .titlePost{
- padding-right: 30px;
+  display: flex ;
+  flex-direction: row;
 }

--- a/frontend/src/app/modules/mips/components/list/list.component.ts
+++ b/frontend/src/app/modules/mips/components/list/list.component.ts
@@ -175,7 +175,7 @@ const language = 'typescript';
     this.ascOrderSorting = this.orderService.order.direction == 'ASC';
     this.subscriptionSearchService = this.searchService.search$.subscribe(
       (data) => {
-        this.search = data;
+        this.search = '';
       }
     );
     this.subscriptionFilterService = this.filterService.filter$.subscribe(


### PR DESCRIPTION
This is for remove the ability to sort by summary on the main page.
![proveSummary](https://user-images.githubusercontent.com/96558830/154086303-7a0aafb6-12a3-40de-a679-003018b84881.jpg)
