### PR TITLE
fix: update plain field when update mip

### DIFF
--- a/backend/src/mips/services/mips.service.spec.ts
+++ b/backend/src/mips/services/mips.service.spec.ts
@@ -1038,13 +1038,18 @@ describe("MIPsService", () => {
 
     describe('update', () => {
         it('update MIP', async () => {
-            const result = await mipsService.update(mipMock._id, mipMock);
+            jest.spyOn(MIPsService.prototype, 'addSearcheableFields')
+                .mockReturnValueOnce(mipSearcheableMock);
+                
+            const result = await mipsService.update(mipMock._id, mipToBeSearcheableMock);
 
             expect(result).toEqual(mipData);
+            expect(MIPsService.prototype.addSearcheableFields).toBeCalledTimes(1);
+            expect(MIPsService.prototype.addSearcheableFields).toBeCalledWith(mipToBeSearcheableMock);
             expect(findOneAndUpdate).toBeCalledTimes(1);
             expect(findOneAndUpdate).toBeCalledWith(
                 { _id: mipMock._id },
-                { $set: mipMock },
+                { $set: mipSearcheableMock },
                 { new: true, useFindAndModify: false }
             );
             expect(leanOne).toBeCalledTimes(1);

--- a/backend/src/mips/services/mips.service.ts
+++ b/backend/src/mips/services/mips.service.ts
@@ -542,7 +542,7 @@ export class MIPsService {
     return this.mipsDoc
       .findOneAndUpdate(
         { _id: id },
-        { $set: mIPs },
+        { $set: this.addSearcheableFields(mIPs) },
         { new: true, useFindAndModify: false }
       )
       .lean(true);


### PR DESCRIPTION
Adding plain fields to MIP when update it.

Besides, the unit tests were updated to cover the new flows introduced in the file: MIPsService

card: https://trello.com/c/GHwlT7HH/348-fix-the-issue-with-mip55c3sp8